### PR TITLE
Add .NET Global tools to path

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,9 @@
 ARG VARIANT="6.0-focal"
 FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
 
+# Add .NET global tools path
+ENV PATH $PATH:/home/vscode/.dotnet:/home/vscode/.dotnet/tools
+
 # [Choice] Node.js version: none, lts/*, 18, 16, 14
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi


### PR DESCRIPTION
This changes allows: 
- Easy use of .NET Global tools out of the box
- Enables Polyglot Notebooks SQL kernel to work out of the box (It relies on a global .NET tool to be in path), if using .NET 7